### PR TITLE
attractor: add masori variants (and fix max cape typos)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.30'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/weaponcharges/AttractorDefinition.java
+++ b/src/main/java/com/weaponcharges/AttractorDefinition.java
@@ -24,31 +24,50 @@
  */
 package com.weaponcharges;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import net.runelite.api.ItemID;
+import org.apache.commons.lang3.ArrayUtils;
 
-@AllArgsConstructor
 @Getter
 enum AttractorDefinition
 {
-	ATTRACTOR(ItemID.AVAS_ATTRACTOR, 0.2f, 0.16f, 0.64f),
-	ACCUMULATOR(ItemID.AVAS_ACCUMULATOR, 0.2f, 0.08f, 0.72f),
-	ACCUMULATOR_MAX_CAPE(ItemID.AVAS_ACCUMULATOR, 0.2f, 0.08f, 0.72f),
-	ACCUMULATOR_RANGE_CAPE(ItemID.RANGING_CAPE, 0.2f, 0.08f, 0.72f),
-	ASSEMBLER(ItemID.AVAS_ASSEMBLER, 0.2f, 0.0f, 0.8f),
-	ASSEMBLER_MAX_CAPE(ItemID.AVAS_ACCUMULATOR, 0.2f, 0.08f, 0.72f);
+	ATTRACTOR(0.2f, 0.16f, 0.64f, 
+		ItemID.AVAS_ATTRACTOR
+	),
+	ACCUMULATOR(0.2f, 0.08f, 0.72f, 
+		ItemID.AVAS_ACCUMULATOR, 
+		ItemID.RANGING_CAPE, 
+		ItemID.ACCUMULATOR_MAX_CAPE
+	),
+	ASSEMBLER(0.2f, 0.0f, 0.8f, 
+		ItemID.AVAS_ASSEMBLER,
+		ItemID.AVAS_ASSEMBLER_L,
+		ItemID.ASSEMBLER_MAX_CAPE,
+		ItemID.ASSEMBLER_MAX_CAPE_L,
+		ItemID.MASORI_ASSEMBLER,
+		ItemID.MASORI_ASSEMBLER_L,
+		ItemID.MASORI_ASSEMBLER_MAX_CAPE,
+		ItemID.MASORI_ASSEMBLER_MAX_CAPE_L
+	);
 
-	private int itemId;
-	private float breakOnImpactChance;
-	private float dropToFloorChance;
-	private float savedChance;
+	private final float breakOnImpactChance;
+	private final float dropToFloorChance;
+	private final float savedChance;
+	private final int[] itemIds;
+
+	AttractorDefinition(float breakOnImpactChance, float dropToFloorChance, float savedChance, int... itemIds)
+	{
+		this.breakOnImpactChance = breakOnImpactChance;
+		this.dropToFloorChance = dropToFloorChance;
+		this.savedChance = savedChance;
+		this.itemIds = itemIds;
+	}
 
 	static AttractorDefinition getAttractorById(int itemId)
 	{
 		for (AttractorDefinition attractorDefinition : values())
 		{
-			if (attractorDefinition.getItemId() == itemId)
+			if (ArrayUtils.contains(attractorDefinition.getItemIds(), itemId))
 			{
 				return attractorDefinition;
 			}


### PR DESCRIPTION
Kept noticing my blowpipe was being tracked as draining charges too quickly so I took a look.

Also reworked the class a bit to reduce duplicate entries, and there were a couple typos with the max cape variants just using the ava's accumulator id:

https://github.com/geheur/weapon-charges/blob/9c368c8c183b1965107dc89d4dab6196738a5014/src/main/java/com/weaponcharges/AttractorDefinition.java#L37